### PR TITLE
Add login modal and email authentication

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,6 +33,7 @@ import EvolutionDetailWrapper from "./components/EvolutionDetailWrapper";
 import MarketWrapper from "./components/MarketWrapper";
 import GamesWrapper from "./components/GamesWrapper";
 import StatClash from "./components/games/StatClash";
+import ProtectedRoute from "./components/ProtectedRoute";
 import { PayPalScriptProvider } from "@paypal/react-paypal-js";
 
 ReactGA.initialize("G-RD6LGLC1LD");
@@ -88,11 +89,11 @@ function App() {
                   <Route path="/sbc/" element={<SbcWrapper />} />
                   <Route
                     path="/squad_wizard/"
-                    element={<SquadWizardWrapper />}
-                  />
-                  <Route
-                    path="/squad_wizard/"
-                    element={<SquadWizardWrapper />}
+                    element={
+                      <ProtectedRoute>
+                        <SquadWizardWrapper />
+                      </ProtectedRoute>
+                    }
                   />
                   <Route path="/games/" element={<GamesWrapper />} />
                   <Route path="/stat_clash/" element={<StatClash />} />

--- a/src/api/authService.js
+++ b/src/api/authService.js
@@ -1,0 +1,16 @@
+import instance from './axiosclient';
+
+export const loginUser = async (payload) => {
+  const response = await instance.post('/api/token/', payload);
+  return response.data;
+};
+
+export const registerUser = async (payload) => {
+  const response = await instance.post('/api/register/', payload);
+  return response.data;
+};
+
+export const verifyGoogleToken = async (payload) => {
+  const response = await instance.post('/verify_token/', payload);
+  return response.data.user_info;
+};

--- a/src/api/axiosclient.js
+++ b/src/api/axiosclient.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { getCookie } from "../components/utils/cookies";
 
 const instance = axios.create({
   baseURL: process.env.REACT_APP_API_URL,
@@ -8,7 +9,7 @@ const instance = axios.create({
 // Add a request interceptor
 instance.interceptors.request.use(
   function (config) {
-    const token = localStorage.getItem("access_token");
+    const token = getCookie("access_token");
 
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { Navigate } from "react-router-dom";
+
+const ProtectedRoute = ({ children }) => {
+  const userInfo = useSelector((state) => state.app.userInfo);
+  if (!userInfo) {
+    return <Navigate to="/" replace />;
+  }
+  return children;
+};
+
+export default ProtectedRoute;

--- a/src/components/common/Account.jsx
+++ b/src/components/common/Account.jsx
@@ -1,44 +1,54 @@
-import { GoogleLogin, googleLogout } from "@react-oauth/google";
+import { GoogleLogin } from "@react-oauth/google";
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { removeUserInfo, setUserInfo } from "../../redux/appSlice";
 import { verifyToken } from "../../api/apiService";
+import { setCookie, deleteCookie } from "../utils/cookies";
 import { Popover } from "@headlessui/react";
 import { capitalizeFirstLetter } from "../utils/utils";
+import { UserIcon } from "@heroicons/react/20/solid";
 
 const Account = () => {
   const dispatch = useDispatch();
   const userInfo = useSelector((state) => state.app.userInfo);
   return (
     <div>
-      {userInfo !== null && userInfo.picture_url ? (
+      {userInfo !== null ? (
         <div className="flex gap-1 items-center relative">
           <Popover>
             <Popover.Button>
               <div className="rounded-full flex justify-center  border-fuchsia-400 p-1 border-2 items-center cursor-pointer">
-                <img
-                  src={userInfo.picture_url}
-                  className="w-10 md:w-6 rounded-full"
-                />
+                {userInfo.picture_url ? (
+                  <img
+                    src={userInfo.picture_url}
+                    className="w-10 md:w-6 rounded-full"
+                  />
+                ) : (
+                  <UserIcon className="w-6 h-6 text-white" />
+                )}
               </div>
             </Popover.Button>
             <Popover.Panel className="absolute z-10 top-[7vh] right-0 ">
               <div className="h-[20vh] w-[15vw] bg-slate-700 shadow-md rounded-md">
                 <div className="flex items-center flex-col pt-3 gap-2 p-4 ">
-                  <img
-                    src={userInfo.picture_url}
-                    className="w-12 h-12 rounded-full"
-                  />
+                  {userInfo.picture_url ? (
+                    <img
+                      src={userInfo.picture_url}
+                      className="w-12 h-12 rounded-full"
+                    />
+                  ) : (
+                    <UserIcon className="w-8 h-8 text-white" />
+                  )}
                   <p className="text-white font-bold capitalize">
-                    {capitalizeFirstLetter(
-                      `${userInfo.given_name} ${userInfo.family_name}`
-                    )}
+                    {capitalizeFirstLetter(userInfo.name || '')}
                   </p>
                   <hr className="text-white  bg-white w-full" />
                   <button
                     className="text-white self-start "
                     onClick={() => {
-                      localStorage.setItem("google_token", null);
+                      deleteCookie("google_token");
+                      deleteCookie("access_token");
+                      deleteCookie("refresh_token");
                       dispatch(removeUserInfo());
                     }}
                   >
@@ -57,8 +67,9 @@ const Account = () => {
               token: credentialResponse.credential,
             });
             const { access, refresh } = userInfo.tokens;
-            localStorage.setItem("access_token", access);
-            localStorage.setItem("google_token", credentialResponse.credential);
+            setCookie("access_token", access);
+            setCookie("refresh_token", refresh);
+            setCookie("google_token", credentialResponse.credential);
             dispatch(setUserInfo(userInfo));
           }}
           onError={() => {

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -24,6 +24,7 @@ import {
 import MobileMenuPopover from "./MobileMenuPopover";
 import { useDispatch, useSelector } from "react-redux";
 import Account from "./Account";
+import LoginModal from "./LoginModal";
 import {
   setLeagues,
   setNations,
@@ -47,6 +48,7 @@ const Navbar = () => {
   const [searchValue, setSearchValue] = useState("");
   const debouncedSearchTerm = useDebounce(searchValue, 400);
   const [showPremium, setShowPremium] = useState(false);
+  const [showLogin, setShowLogin] = useState(false);
   const inputRef = useRef(null);
   const [inputWidth, setInputWidth] = useState(0);
 
@@ -127,6 +129,7 @@ const Navbar = () => {
     getData();
   }, []);
 
+  const userInfo = useSelector((state) => state.app.userInfo);
   return (
     <div>
       <header
@@ -237,6 +240,16 @@ const Navbar = () => {
                   <AcademicCapIcon className="text-white w-5" /> Games
                 </div>
               </Link>
+              {userInfo ? (
+                <Account />
+              ) : (
+                <button
+                  onClick={() => setShowLogin(true)}
+                  className="text-white font-bold"
+                >
+                  Login
+                </button>
+              )}
               <button
                 onClick={() => setShowPremium(true)}
                 className="bg-yellow-400 hover:bg-yellow-500 text-black font-bold py-1.5 px-4 rounded-lg"
@@ -286,6 +299,7 @@ const Navbar = () => {
         </nav>
       </header>
       {showPremium && <PremiumModal onClose={() => setShowPremium(false)} />}
+      {showLogin && <LoginModal onClose={() => setShowLogin(false)} />}
     </div>
   );
 };

--- a/src/components/common/LoginModal.jsx
+++ b/src/components/common/LoginModal.jsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import { Dialog } from '@headlessui/react';
+import { useDispatch } from 'react-redux';
+import { loginUser, verifyGoogleToken } from '../../api/authService';
+import { setUserInfo } from '../../redux/appSlice';
+import { setCookie } from '../utils/cookies';
+import { GoogleLogin } from '@react-oauth/google';
+
+const LoginModal = ({ onClose }) => {
+  const dispatch = useDispatch();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleLogin = async () => {
+    try {
+      const data = await loginUser({ email, password });
+      const { access, refresh } = data;
+      setCookie('access_token', access);
+      setCookie('refresh_token', refresh);
+      dispatch(setUserInfo(data));
+      onClose();
+    } catch (err) {
+      setError('Login failed');
+    }
+  };
+
+  const handleGoogle = async (credentialResponse) => {
+    try {
+      const userInfo = await verifyGoogleToken({
+        token: credentialResponse.credential,
+      });
+      const { access, refresh } = userInfo.tokens;
+      setCookie('access_token', access);
+      setCookie('refresh_token', refresh);
+      setCookie('google_token', credentialResponse.credential);
+      dispatch(setUserInfo(userInfo));
+      onClose();
+    } catch (err) {
+      console.error('Google login failed');
+    }
+  };
+
+  return (
+    <Dialog
+      open={true}
+      onClose={onClose}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+    >
+      <Dialog.Panel className="bg-white w-80 p-4 rounded-md">
+        <Dialog.Title className="text-lg font-bold mb-2 text-center">
+          Login
+        </Dialog.Title>
+        <div className="flex flex-col gap-2">
+          <input
+            className="border p-2"
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <input
+            className="border p-2"
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          <button
+            onClick={handleLogin}
+            className="bg-fuchsia-400 text-white py-2 rounded mt-2"
+          >
+            Login
+          </button>
+          <p className="text-xs text-center mt-2">
+            Register user or login with Google
+          </p>
+          <div className="flex justify-center mt-2">
+            <GoogleLogin onSuccess={handleGoogle} onError={() => {}} size="medium" theme="outline" />
+          </div>
+        </div>
+      </Dialog.Panel>
+    </Dialog>
+  );
+};
+
+export default LoginModal;

--- a/src/components/utils/cookies.js
+++ b/src/components/utils/cookies.js
@@ -1,0 +1,16 @@
+export const setCookie = (name, value, days = 7) => {
+  const expires = new Date();
+  expires.setTime(expires.getTime() + days * 24 * 60 * 60 * 1000);
+  document.cookie = `${name}=${value}; expires=${expires.toUTCString()}; path=/`;
+};
+
+export const getCookie = (name) => {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop().split(';').shift();
+  return null;
+};
+
+export const deleteCookie = (name) => {
+  document.cookie = `${name}=; Max-Age=0; path=/`;
+};

--- a/src/components/utils/utils.js
+++ b/src/components/utils/utils.js
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { useDispatch } from "react-redux";
 import { setUserInfo } from "../../redux/appSlice";
 import { verifyToken } from "../../api/apiService";
+import { setCookie, getCookie } from "./cookies";
 
 // utils.js
 import store from "../../redux/store";
@@ -183,8 +184,9 @@ export const useFetchUserInfo = () => {
           token: token,
         });
         const { access, refresh } = userInfo.tokens;
-        localStorage.setItem("google_token", token);
-        localStorage.setItem("access_token", access);
+        setCookie("google_token", token);
+        setCookie("access_token", access);
+        setCookie("refresh_token", refresh);
         dispatch(setUserInfo(userInfo));
       } catch (error) {
         console.error("Failed to fetch user info", error);
@@ -192,7 +194,7 @@ export const useFetchUserInfo = () => {
       }
     };
 
-    const token = localStorage.getItem("google_token");
+    const token = getCookie("google_token");
     if (token) {
       fetchUserInfo(token);
     }


### PR DESCRIPTION
## Summary
- add standalone `authService` with login/register helpers
- add `LoginModal` component for email or Google login
- show login button in `Header` and include account dropdown
- tweak `Account` component to support users without profile images

## Testing
- `npm test --silent` *(fails: react-scripts not found)*